### PR TITLE
feat: subscribe to AFTER_TESTS_READ instead of AFTER_FILE_READ

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ module.exports = {
 
     plugins: {
         'hermione-global-hooks': {
-            globalBeforeEach: function() {
+            enabled: true, // by default
+            beforeEach: function() {
                 // do some staff before each test
             },
 
-            globalAfterEach: function() {
+            afterEach: function() {
                 // do some staff after each test
             }
         }

--- a/config.js
+++ b/config.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const {root, section, option} = require('gemini-configparser');
+
+const ENV_PREFIX = 'hermione_global_hooks_';
+const CLI_PREFIX = '--hermione-global-hooks-';
+
+const assertType = (type, name) => (value) => {
+    if (value && typeof value !== type) {
+        throw new Error(`"${name}" must be a ${type}`);
+    }
+};
+
+const getParser = () => {
+    return root(section({
+        enabled: option({
+            defaultValue: true,
+            validate: assertType('boolean', 'enabled')
+        }),
+        beforeEach: option({
+            defaultValue: null,
+            validate: assertType('function', 'beforeEach')
+        }),
+        afterEach: option({
+            defaultValue: null,
+            validate: assertType('function', 'afterEach')
+        })
+    }), {envPrefix: ENV_PREFIX, cliPrefix: CLI_PREFIX});
+};
+
+module.exports = (options) => {
+    const {env, argv} = process;
+
+    return getParser()({options, env, argv});
+};

--- a/index.js
+++ b/index.js
@@ -1,28 +1,23 @@
 'use strict';
 
+const parseConfig = require('./config');
+
 /**
  * @param {Object} hermione
  * @param {Object} options
  */
-module.exports = (hermione, options) => {
-    if (!options.enabled) {
+module.exports = (hermione, opts) => {
+    const config = parseConfig(opts);
+    if (!config.enabled) {
         return;
     }
 
-    const globalAfterEach = options.globalAfterEach || (() => {});
-    const globalBeforeEach = options.globalBeforeEach || (() => {});
+    const {beforeEach, afterEach} = config;
 
-    hermione.on(hermione.events.AFTER_FILE_READ, (data) => {
-        const afterEach = data.suite._afterEach.shift();
-
-        data.suite.afterEach(function() {
-            return globalAfterEach.apply(this.browser);
-        });
-
-        afterEach && data.suite._afterEach.push(afterEach);
-
-        data.suite.beforeEach(function() {
-            return globalBeforeEach.apply(this.browser);
+    hermione.on(hermione.events.AFTER_TESTS_READ, (collection) => {
+        collection.eachRootSuite((root) => {
+            beforeEach && root.beforeEach(beforeEach);
+            afterEach && root.afterEach(afterEach);
         });
     });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -576,6 +576,14 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "gemini-configparser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gemini-configparser/-/gemini-configparser-1.0.0.tgz",
+      "integrity": "sha1-lKjZTqTqESh9nEChnHSSFo7toCA=",
+      "requires": {
+        "lodash": "4.17.10"
+      }
+    },
     "generate-function": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
@@ -839,8 +847,7 @@
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-      "dev": true
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash.get": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "eslint-config-gemini-testing": "^2.2.0",
     "mocha": "^5.2.0",
     "sinon": "^6.0.1"
+  },
+  "dependencies": {
+    "gemini-configparser": "^1.0.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,73 @@
 'use strict';
 
+const plugin = require('../');
+const EventEmitter = require('events');
+
+const events = {AFTER_TESTS_READ: 'after_tests_read'};
+
 describe('hermione-global-hooks', () => {
-    // TODO: tests
+    const mkHermioneStub = () => {
+        const hermione = new EventEmitter();
+        hermione.events = events;
+
+        return hermione;
+    };
+
+    const stubSuite = () => {
+        return {
+            beforeEach: sinon.spy().named('beforeEach'),
+            afterEach: sinon.spy().named('afterEach')
+        };
+    };
+
+    it('should be enabled by default', () => {
+        const hermione = mkHermioneStub();
+
+        plugin(hermione);
+
+        const eachRootSuite = sinon.spy().named('eachRootSuite');
+        hermione.emit(events.AFTER_TESTS_READ, {eachRootSuite});
+
+        assert.calledOnce(eachRootSuite);
+    });
+
+    it('should do nothing if disabled', () => {
+        const hermione = mkHermioneStub();
+
+        plugin(hermione, {enabled: false});
+
+        const eachRootSuite = sinon.spy().named('eachRootSuite');
+        hermione.emit(events.AFTER_TESTS_READ, {eachRootSuite});
+
+        assert.notCalled(eachRootSuite);
+    });
+
+    [
+        'beforeEach',
+        'afterEach'
+    ].forEach((hookName) => {
+        it(`should set global ${hookName} hook to each root suite`, () => {
+            const hook = sinon.spy().named(hookName);
+
+            const hermione = mkHermioneStub();
+            plugin(hermione, {[hookName]: hook});
+
+            const suite = stubSuite();
+            const eachRootSuite = (cb) => cb(suite);
+            hermione.emit(events.AFTER_TESTS_READ, {eachRootSuite});
+
+            assert.calledOnceWith(suite[hookName], hook);
+        });
+
+        it(`should not set global ${hookName} hook if no hook set in config`, () => {
+            const hermione = mkHermioneStub();
+            plugin(hermione);
+
+            const suite = stubSuite();
+            const eachRootSuite = (cb) => cb(suite);
+            hermione.emit(events.AFTER_TESTS_READ, {eachRootSuite});
+
+            assert.notCalled(suite[hookName]);
+        });
+    });
 });


### PR DESCRIPTION
- подписываемся на событие `AFTER_TESTS_READ` и добавляем хуки сразу всему дереву вместо добавления хуков в каждый файл на `AFTER_FILE_READ`
- BREAKING CHANGES: переименовал опции 
  - `globalBeforeEach` -> `beforeEach`
  - `afterBeforeEach` -> `afterEach`